### PR TITLE
[init] #10 Entity 초기 세팅

### DIFF
--- a/domain/src/main/kotlin/entity/advertisement/Advertisement.kt
+++ b/domain/src/main/kotlin/entity/advertisement/Advertisement.kt
@@ -1,0 +1,28 @@
+package entity.advertisement
+
+import entity.common.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "advertisement")
+class Advertisement private constructor(
+    imageUrl: String
+) : BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+
+    @Column(nullable = false)
+    var imageUrl: String = imageUrl
+        protected set
+
+    companion object {
+        fun of(imageUrl: String) = Advertisement(imageUrl)
+    }
+}

--- a/domain/src/main/kotlin/entity/comment/Comment.kt
+++ b/domain/src/main/kotlin/entity/comment/Comment.kt
@@ -1,0 +1,45 @@
+package entity.comment
+
+import entity.common.BaseTimeEntity
+import entity.user.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "comment")
+class Comment private constructor(
+    user: User?,
+    isPublic: Boolean,
+    body: String
+) : BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    val id: Long = 0
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    var user: User? = user
+        protected set
+
+    @Column(nullable = false)
+    var isPublic: Boolean = isPublic
+        protected set
+
+    @Column(nullable = false, length = 500)
+    var body: String = body
+        protected set
+
+    companion object {
+        fun of(user: User?, isPublic: Boolean, body: String) =
+            Comment(user, isPublic, body)
+    }
+}

--- a/domain/src/main/kotlin/entity/common/BaseTimeEntity.kt
+++ b/domain/src/main/kotlin/entity/common/BaseTimeEntity.kt
@@ -1,0 +1,22 @@
+package entity.common
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    var createdAt: LocalDateTime? = null
+        protected set
+
+    @LastModifiedDate
+    var modifiedAt: LocalDateTime? = null
+        protected set
+}

--- a/domain/src/main/kotlin/entity/group/EveryGroup.kt
+++ b/domain/src/main/kotlin/entity/group/EveryGroup.kt
@@ -1,0 +1,72 @@
+package entity.group
+
+import entity.timeslot.GongbaekTimeSlot
+import entity.user.User
+import enums.Category
+import enums.Status
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.PrimaryKeyJoinColumn
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+@Entity
+@Table(name = "every_group")
+@PrimaryKeyJoinColumn(name = "id")
+class EveryGroup private constructor(
+    creatorUser: User?,
+    gongbaekTimeSlot: GongbaekTimeSlot,
+    category: Category,
+    coverImg: Int,
+    location: String,
+    status: Status,
+    maxPeopleCount: Int,
+    currentPeopleCount: Int,
+    introduction: String,
+    title: String,
+    dueDate: LocalDate
+) : GroupBase(
+    creatorUser,
+    gongbaekTimeSlot,
+    category,
+    coverImg,
+    location,
+    status,
+    maxPeopleCount,
+    currentPeopleCount,
+    introduction,
+    title
+) {
+
+    @Column(nullable = false)
+    var dueDate: LocalDate = dueDate
+        protected set
+
+    companion object {
+        fun of(
+            creatorUser: User?,
+            gongbaekTimeSlot: GongbaekTimeSlot,
+            category: Category,
+            coverImg: Int,
+            location: String,
+            status: Status,
+            maxPeopleCount: Int,
+            currentPeopleCount: Int,
+            introduction: String,
+            title: String,
+            dueDate: LocalDate
+        ) = EveryGroup(
+            creatorUser,
+            gongbaekTimeSlot,
+            category,
+            coverImg,
+            location,
+            status,
+            maxPeopleCount,
+            currentPeopleCount,
+            introduction,
+            title,
+            dueDate
+        )
+    }
+}

--- a/domain/src/main/kotlin/entity/group/GroupBase.kt
+++ b/domain/src/main/kotlin/entity/group/GroupBase.kt
@@ -1,0 +1,80 @@
+package entity.group
+
+import entity.common.BaseTimeEntity
+import entity.timeslot.GongbaekTimeSlot
+import entity.user.User
+import enums.Category
+import enums.Status
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@Table(name = "group_base")
+abstract class GroupBase protected constructor(
+    creatorUser: User?,
+    gongbaekTimeSlot: GongbaekTimeSlot,
+    category: Category,
+    coverImg: Int?,
+    location: String,
+    status: Status,
+    maxPeopleCount: Int,
+    currentPeopleCount: Int,
+    introduction: String,
+    title: String
+) : BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_user_id")
+    var creatorUser: User? = creatorUser
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gongbaek_time_slot_id", nullable = false)
+    var gongbaekTimeSlot: GongbaekTimeSlot = gongbaekTimeSlot
+        protected set
+
+    @Column(nullable = false)
+    var category: Category = category
+        protected set
+
+    var coverImg: Int? = coverImg
+        protected set
+
+    @Column(nullable = false)
+    var location: String = location
+        protected set
+
+    @Column(nullable = false)
+    var status: Status = status
+        protected set
+
+    @Column(nullable = false)
+    var maxPeopleCount: Int = maxPeopleCount
+        protected set
+
+    @Column(nullable = false)
+    var currentPeopleCount: Int = currentPeopleCount
+        protected set
+
+    @Column(nullable = false)
+    var introduction: String = introduction
+        protected set
+
+    @Column(nullable = false)
+    var title: String = title
+        protected set
+}

--- a/domain/src/main/kotlin/entity/group/OnceGroup.kt
+++ b/domain/src/main/kotlin/entity/group/OnceGroup.kt
@@ -1,0 +1,72 @@
+package entity.group
+
+import entity.timeslot.GongbaekTimeSlot
+import entity.user.User
+import enums.Category
+import enums.Status
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.PrimaryKeyJoinColumn
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+@Entity
+@Table(name = "once_group")
+@PrimaryKeyJoinColumn(name = "id")
+class OnceGroup private constructor(
+    creatorUser: User?,
+    gongbaekTimeSlot: GongbaekTimeSlot,
+    category: Category,
+    coverImg: Int,
+    location: String,
+    status: Status,
+    maxPeopleCount: Int,
+    currentPeopleCount: Int,
+    introduction: String,
+    title: String,
+    groupDate: LocalDate
+) : GroupBase(
+    creatorUser,
+    gongbaekTimeSlot,
+    category,
+    coverImg,
+    location,
+    status,
+    maxPeopleCount,
+    currentPeopleCount,
+    introduction,
+    title
+) {
+
+    @Column(nullable = false)
+    var groupDate: LocalDate = groupDate
+        protected set
+
+    companion object {
+        fun of(
+            creatorUser: User?,
+            gongbaekTimeSlot: GongbaekTimeSlot,
+            category: Category,
+            coverImg: Int,
+            location: String,
+            status: Status,
+            maxPeopleCount: Int,
+            currentPeopleCount: Int,
+            introduction: String,
+            title: String,
+            groupDate: LocalDate
+        ) = OnceGroup(
+            creatorUser,
+            gongbaekTimeSlot,
+            category,
+            coverImg,
+            location,
+            status,
+            maxPeopleCount,
+            currentPeopleCount,
+            introduction,
+            title,
+            groupDate
+        )
+    }
+}

--- a/domain/src/main/kotlin/entity/school/School.kt
+++ b/domain/src/main/kotlin/entity/school/School.kt
@@ -1,0 +1,41 @@
+package entity.school
+
+import entity.common.BaseTimeEntity
+import entity.user.User
+import jakarta.persistence.*
+
+@Entity
+@Table(
+    name = "school",
+    indexes = [Index(name = "school_name_idx", columnList = "schoolName")]
+)
+class School private constructor(
+    schoolName: String,
+    schoolDomain: String
+) : BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "school_id")
+    val id: Long = 0
+
+    @Column(nullable = false, unique = true)
+    var schoolName: String = schoolName
+        protected set
+
+    @Column(nullable = false)
+    var schoolDomain: String = schoolDomain
+        protected set
+
+    @OneToMany(mappedBy = "school", fetch = FetchType.LAZY)
+    protected val _schoolMajors: MutableList<SchoolMajor> = mutableListOf()
+    val schoolMajors: List<SchoolMajor> get() = _schoolMajors.toList()
+
+    @OneToMany(mappedBy = "school", fetch = FetchType.LAZY)
+    protected val _users: MutableList<User> = mutableListOf()
+    val users: List<User> get() = _users.toList()
+
+    companion object {
+        fun of(schoolName: String, schoolDomain: String) = School(schoolName, schoolDomain)
+    }
+}

--- a/domain/src/main/kotlin/entity/school/SchoolMajor.kt
+++ b/domain/src/main/kotlin/entity/school/SchoolMajor.kt
@@ -1,0 +1,38 @@
+package entity.school
+
+import entity.common.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "school_major")
+class SchoolMajor private constructor(
+    school: School,
+    majorName: String
+) : BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "school_major_id")
+    val id: Long = 0
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id")
+    var school: School = school
+        protected set
+
+    @Column(name = "school_major_name", nullable = false)
+    var majorName: String = majorName
+        protected set
+
+    companion object {
+        fun of(school: School, majorName: String) = SchoolMajor(school, majorName)
+    }
+}

--- a/domain/src/main/kotlin/entity/timeslot/GongbaekTimeSlot.kt
+++ b/domain/src/main/kotlin/entity/timeslot/GongbaekTimeSlot.kt
@@ -2,26 +2,17 @@ package entity.timeslot
 
 import entity.user.User
 import enums.WeekDay
-import jakarta.persistence.Entity
-import jakarta.persistence.PrimaryKeyJoinColumn
-import jakarta.persistence.Table
+import jakarta.persistence.*
 
 @Entity
-@Table(name = "gongbaek_time_slot")
-@PrimaryKeyJoinColumn(name = "id")
-class GongbaekTimeSlot private constructor(
-    weekDay: WeekDay,
-    startTime: Double,
-    endTime: Double,
-    user: User
-) : TimeSlotBase(weekDay, startTime, endTime, user) {
-
-    companion object {
-        fun of(
-            weekDay: WeekDay,
-            startTime: Double,
-            endTime: Double,
-            user: User
-        ) = GongbaekTimeSlot(weekDay, startTime, endTime, user)
-    }
-}
+@Table(name = "time_slot")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "slot_type")
+open class TimeSlotBase(
+    @Enumerated(EnumType.STRING)
+    val weekDay: WeekDay,
+    val startTime: Double,
+    val endTime: Double,
+    @ManyToOne
+    val user: User
+)

--- a/domain/src/main/kotlin/entity/timeslot/GongbaekTimeSlot.kt
+++ b/domain/src/main/kotlin/entity/timeslot/GongbaekTimeSlot.kt
@@ -2,17 +2,19 @@ package entity.timeslot
 
 import entity.user.User
 import enums.WeekDay
-import jakarta.persistence.*
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
 
 @Entity
-@Table(name = "time_slot")
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name = "slot_type")
-open class TimeSlotBase(
-    @Enumerated(EnumType.STRING)
-    val weekDay: WeekDay,
-    val startTime: Double,
-    val endTime: Double,
-    @ManyToOne
-    val user: User
+@DiscriminatorValue("GONGBAEK")
+class GongbaekTimeSlot(
+    weekDay: WeekDay,
+    startTime: Double,
+    endTime: Double,
+    user: User
+) : TimeSlotBase(
+    weekDay = weekDay,
+    startTime = startTime,
+    endTime = endTime,
+    user = user
 )

--- a/domain/src/main/kotlin/entity/timeslot/GongbaekTimeSlot.kt
+++ b/domain/src/main/kotlin/entity/timeslot/GongbaekTimeSlot.kt
@@ -1,0 +1,27 @@
+package entity.timeslot
+
+import entity.user.User
+import enums.WeekDay
+import jakarta.persistence.Entity
+import jakarta.persistence.PrimaryKeyJoinColumn
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "gongbaek_time_slot")
+@PrimaryKeyJoinColumn(name = "id")
+class GongbaekTimeSlot private constructor(
+    weekDay: WeekDay,
+    startTime: Double,
+    endTime: Double,
+    user: User
+) : TimeSlotBase(weekDay, startTime, endTime, user) {
+
+    companion object {
+        fun of(
+            weekDay: WeekDay,
+            startTime: Double,
+            endTime: Double,
+            user: User
+        ) = GongbaekTimeSlot(weekDay, startTime, endTime, user)
+    }
+}

--- a/domain/src/main/kotlin/entity/timeslot/LectureTimeSlot.kt
+++ b/domain/src/main/kotlin/entity/timeslot/LectureTimeSlot.kt
@@ -2,26 +2,14 @@ package entity.timeslot
 
 import entity.user.User
 import enums.WeekDay
+import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
-import jakarta.persistence.PrimaryKeyJoinColumn
-import jakarta.persistence.Table
 
 @Entity
-@Table(name = "lecture_time_slot")
-@PrimaryKeyJoinColumn(name = "id")
-class LectureTimeSlot private constructor(
+@DiscriminatorValue("LECTURE")
+class LectureTimeSlot(
     weekDay: WeekDay,
     startTime: Double,
     endTime: Double,
     user: User
-) : TimeSlotBase(weekDay, startTime, endTime, user) {
-
-    companion object {
-        fun of(
-            weekDay: WeekDay,
-            startTime: Double,
-            endTime: Double,
-            user: User
-        ) = LectureTimeSlot(weekDay, startTime, endTime, user)
-    }
-}
+) : TimeSlotBase(weekDay, startTime, endTime, user)

--- a/domain/src/main/kotlin/entity/timeslot/LectureTimeSlot.kt
+++ b/domain/src/main/kotlin/entity/timeslot/LectureTimeSlot.kt
@@ -1,0 +1,27 @@
+package entity.timeslot
+
+import entity.user.User
+import enums.WeekDay
+import jakarta.persistence.Entity
+import jakarta.persistence.PrimaryKeyJoinColumn
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "lecture_time_slot")
+@PrimaryKeyJoinColumn(name = "id")
+class LectureTimeSlot private constructor(
+    weekDay: WeekDay,
+    startTime: Double,
+    endTime: Double,
+    user: User
+) : TimeSlotBase(weekDay, startTime, endTime, user) {
+
+    companion object {
+        fun of(
+            weekDay: WeekDay,
+            startTime: Double,
+            endTime: Double,
+            user: User
+        ) = LectureTimeSlot(weekDay, startTime, endTime, user)
+    }
+}

--- a/domain/src/main/kotlin/entity/timeslot/LectureTimeSlot.kt
+++ b/domain/src/main/kotlin/entity/timeslot/LectureTimeSlot.kt
@@ -12,4 +12,9 @@ class LectureTimeSlot(
     startTime: Double,
     endTime: Double,
     user: User
-) : TimeSlotBase(weekDay, startTime, endTime, user)
+) : TimeSlotBase(
+    weekDay = weekDay,
+    startTime = startTime,
+    endTime = endTime,
+    user = user
+)

--- a/domain/src/main/kotlin/entity/timeslot/TimeSlotBase.kt
+++ b/domain/src/main/kotlin/entity/timeslot/TimeSlotBase.kt
@@ -1,0 +1,47 @@
+package entity.timeslot
+
+import entity.user.User
+import enums.WeekDay
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@Table(name = "time_slot_base")
+abstract class TimeSlotBase protected constructor(
+    weekDay: WeekDay,
+    startTime: Double,
+    endTime: Double,
+    user: User
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "base_time_slot_id")
+    val id: Long = 0
+
+    @Column(nullable = false)
+    var weekDay: WeekDay = weekDay
+        protected set
+
+    @Column(nullable = false)
+    var startTime: Double = startTime
+        protected set
+
+    @Column(nullable = false)
+    var endTime: Double = endTime
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    var user: User = user
+        protected set
+}

--- a/domain/src/main/kotlin/entity/timeslot/TimeSlotBase.kt
+++ b/domain/src/main/kotlin/entity/timeslot/TimeSlotBase.kt
@@ -2,14 +2,39 @@ package entity.timeslot
 
 import entity.user.User
 import enums.WeekDay
-import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorColumn
+import jakarta.persistence.DiscriminatorType
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
 
 @Entity
-@DiscriminatorValue("GONGBAEK")
-class GongbaekTimeSlot(
-    weekDay: WeekDay,
-    startTime: Double,
-    endTime: Double,
-    user: User
-) : TimeSlotBase(weekDay, startTime, endTime, user)
+@Table(name = "time_slot")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "slot_type", discriminatorType = DiscriminatorType.STRING)
+open class TimeSlotBase(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "base_time_slot_id")
+    val id: Long = 0,
+
+    @Enumerated(EnumType.STRING)
+    val weekDay: WeekDay,
+
+    val startTime: Double,
+    val endTime: Double,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User
+)

--- a/domain/src/main/kotlin/entity/timeslot/TimeSlotBase.kt
+++ b/domain/src/main/kotlin/entity/timeslot/TimeSlotBase.kt
@@ -1,5 +1,6 @@
 package entity.timeslot
 
+import entity.common.BaseTimeEntity
 import entity.user.User
 import enums.WeekDay
 import jakarta.persistence.Column
@@ -22,19 +23,23 @@ import jakarta.persistence.Table
 @Table(name = "time_slot")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "slot_type", discriminatorType = DiscriminatorType.STRING)
-open class TimeSlotBase(
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "base_time_slot_id")
-    val id: Long = 0,
-
+open class TimeSlotBase protected constructor(
     @Enumerated(EnumType.STRING)
     val weekDay: WeekDay,
 
+    @Column(nullable = false)
     val startTime: Double,
+
+    @Column(nullable = false)
     val endTime: Double,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val user: User
-)
+) : BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "base_time_slot_id")
+    val id: Long = 0
+}

--- a/domain/src/main/kotlin/entity/timeslot/TimeSlotBase.kt
+++ b/domain/src/main/kotlin/entity/timeslot/TimeSlotBase.kt
@@ -2,46 +2,14 @@ package entity.timeslot
 
 import entity.user.User
 import enums.WeekDay
-import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.Inheritance
-import jakarta.persistence.InheritanceType
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
-import jakarta.persistence.Table
 
 @Entity
-@Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "time_slot_base")
-abstract class TimeSlotBase protected constructor(
+@DiscriminatorValue("GONGBAEK")
+class GongbaekTimeSlot(
     weekDay: WeekDay,
     startTime: Double,
     endTime: Double,
     user: User
-) {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "base_time_slot_id")
-    val id: Long = 0
-
-    @Column(nullable = false)
-    var weekDay: WeekDay = weekDay
-        protected set
-
-    @Column(nullable = false)
-    var startTime: Double = startTime
-        protected set
-
-    @Column(nullable = false)
-    var endTime: Double = endTime
-        protected set
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    var user: User = user
-        protected set
-}
+) : TimeSlotBase(weekDay, startTime, endTime, user)

--- a/domain/src/main/kotlin/entity/user/User.kt
+++ b/domain/src/main/kotlin/entity/user/User.kt
@@ -1,0 +1,111 @@
+package entity.user
+
+import entity.common.BaseTimeEntity
+import entity.school.School
+import entity.school.SchoolMajor
+import enums.Gender
+import enums.Mbti
+import enums.Platform
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Lob
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "user")
+class User private constructor(
+    platform: Platform,
+    platformId: String,
+    email: String,
+    school: School,
+    schoolMajor: SchoolMajor,
+    profileImg: Int?,
+    nickname: String,
+    enterYear: Int,
+    mbti: Mbti,
+    gender: Gender,
+    introduction: String
+) : BaseTimeEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    val id: Long = 0
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var platform: Platform = platform
+        protected set
+
+    @Column(nullable = false, unique = true)
+    var platformId: String = platformId
+        protected set
+
+    @Column(nullable = false)
+    var email: String = email
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id")
+    var school: School = school
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_major_id")
+    var schoolMajor: SchoolMajor = schoolMajor
+        protected set
+
+    @Lob
+    var refreshToken: String? = null
+        protected set
+
+    var profileImg: Int? = profileImg
+        protected set
+
+    @Column(nullable = false)
+    var nickname: String = nickname
+        protected set
+
+    var enterYear: Int = enterYear
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var mbti: Mbti = mbti
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var gender: Gender = gender
+        protected set
+
+    @Column(nullable = false)
+    var introduction: String = introduction
+        protected set
+
+    companion object {
+        fun of(
+            platform: Platform, platformId: String, email: String,
+            school: School, schoolMajor: SchoolMajor, profileImg: Int?,
+            nickname: String, enterYear: Int, mbti: Mbti,
+            gender: Gender, introduction: String
+        ) = User(
+            platform, platformId, email, school, schoolMajor, profileImg,
+            nickname, enterYear, mbti, gender, introduction
+        )
+    }
+
+    fun updateRefreshToken(refreshToken: String?) {
+        this.refreshToken = refreshToken
+    }
+
+    fun validateRefreshToken(refreshToken: String) =
+        this.refreshToken == refreshToken
+}

--- a/domain/src/main/kotlin/entity/userGroup/UserEveryGroup.kt
+++ b/domain/src/main/kotlin/entity/userGroup/UserEveryGroup.kt
@@ -1,0 +1,42 @@
+package entity.userGroup
+
+import entity.common.BaseTimeEntity
+import entity.group.EveryGroup
+import entity.user.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "user_every_group")
+class UserEveryGroup private constructor(
+    participantUser: User,
+    everyGroup: EveryGroup
+) : BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_every_group_id")
+    val id: Long = 0
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_user_id", nullable = false)
+    var participantUser: User = participantUser
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "every_group_id", nullable = false)
+    var everyGroup: EveryGroup = everyGroup
+        protected set
+
+    companion object {
+        fun of(participantUser: User, everyGroup: EveryGroup) =
+            UserEveryGroup(participantUser, everyGroup)
+    }
+}

--- a/domain/src/main/kotlin/entity/userGroup/UserOnceGroup.kt
+++ b/domain/src/main/kotlin/entity/userGroup/UserOnceGroup.kt
@@ -1,0 +1,42 @@
+package entity.userGroup
+
+import entity.common.BaseTimeEntity
+import entity.group.OnceGroup
+import entity.user.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "user_once_group")
+class UserOnceGroup private constructor(
+    participantUser: User,
+    onceGroup: OnceGroup,
+) : BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_once_group_id")
+    val id: Long = 0
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_user_id", nullable = false)
+    var participantUser: User = participantUser
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "once_group_id", nullable = false)
+    var onceGroup: OnceGroup = onceGroup
+        protected set
+
+    companion object {
+        fun of(participantUser: User, onceGroup: OnceGroup) =
+            UserOnceGroup(participantUser, onceGroup)
+    }
+}

--- a/domain/src/main/kotlin/enums/Category.kt
+++ b/domain/src/main/kotlin/enums/Category.kt
@@ -1,0 +1,10 @@
+package enums
+
+enum class Category {
+    STUDY,
+    DINING,
+    EXERCISE,
+    PLAYING,
+    NETWORKING,
+    OTHERS
+}

--- a/domain/src/main/kotlin/enums/Gender.kt
+++ b/domain/src/main/kotlin/enums/Gender.kt
@@ -1,0 +1,6 @@
+package enums
+
+enum class Gender {
+    MAN,
+    WOMAN
+}

--- a/domain/src/main/kotlin/enums/Mbti.kt
+++ b/domain/src/main/kotlin/enums/Mbti.kt
@@ -1,0 +1,20 @@
+package enums
+
+enum class Mbti {
+    ISTJ,
+    ISFJ,
+    INFJ,
+    INTJ,
+    ISTP,
+    ISFP,
+    INFP,
+    INTP,
+    ESTP,
+    ESFP,
+    ENFP,
+    ENTP,
+    ESTJ,
+    ESFJ,
+    ENFJ,
+    ENTJ;
+}

--- a/domain/src/main/kotlin/enums/Platform.kt
+++ b/domain/src/main/kotlin/enums/Platform.kt
@@ -1,0 +1,6 @@
+package enums
+
+enum class Platform {
+    KAKAO,
+    APPLE
+}

--- a/domain/src/main/kotlin/enums/Status.kt
+++ b/domain/src/main/kotlin/enums/Status.kt
@@ -1,0 +1,7 @@
+package enums
+
+enum class Status {
+    RECRUITING,
+    RECRUITED,
+    CLOSED;
+}

--- a/domain/src/main/kotlin/enums/WeekDay.kt
+++ b/domain/src/main/kotlin/enums/WeekDay.kt
@@ -1,0 +1,11 @@
+package enums
+
+enum class WeekDay {
+    MON,
+    TUE,
+    WED,
+    THU,
+    FRI,
+    SAT,
+    SUN;
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### #️⃣관련 이슈
- #10 

### 🎋 작업중인 브랜치
- init/#10

### 💡 작업내용
- 기존에 역정규화되어 있던 ERD 구조를 정규화 설계로 전환하였습니다.
- 각 도메인을 독립적으로 관리할 수 있도록 엔티티를 분리하고, 관계를 명확히 표현했습니다.
- `Group`, `TimeSlot` 등 공통 속성을 가진 엔티티들은 상속 구조(`GroupBase`, `TimeSlotBase`)로 재설계하여 중복을 제거했습니다.

### 🔑 주요 변경사항
- 기존 ERD에서 역정규화된 컬럼을 제거하고, `SchoolMajor`, `School`, `User` 등 각 엔티티를 명확히 분리
- `GroupBase` 및 `TimeSlotBase` 기반 상속 구조 설계
- `UserOnceGroup`, `UserEveryGroup` 연결 엔티티 생성 → 다대다 관계 제거
- Enum 클래스 및 `BaseTimeEntity`(생성일/수정일 자동 관리) 추가

### 🏞 스크린샷
![공백 코틀린 마이그레이션](https://github.com/user-attachments/assets/ee8d93d1-99fd-424a-8740-594cb263eeb2)

closes #10 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 광고, 댓글, 학교, 학과, 사용자, 그룹, 그룹 참여, 타임슬롯 등 다양한 도메인 엔터티가 추가되었습니다.
  * 사용자, 그룹, 타임슬롯, 학교 등 주요 엔터티에 대한 생성 및 속성 관리 기능이 제공됩니다.
  * 그룹은 단일 날짜(OnceGroup) 또는 기간(EveryGroup) 형태로 생성할 수 있습니다.
  * 사용자 정보에 플랫폼, MBTI, 성별, 학교, 학과, 프로필 이미지, 닉네임, 입학년도, 자기소개 등 다양한 속성이 포함됩니다.
  * 그룹 상태, 카테고리, 요일, 성별, MBTI, 플랫폼 등 다양한 열거형(ENUM) 타입이 도입되었습니다.
  * 엔터티 생성 시 생성일/수정일 자동 관리 기능이 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->